### PR TITLE
Feat/pipeline

### DIFF
--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -35,7 +35,8 @@ jobs:
           sudo apt-get install -y dart
 
       - name: Run Dart Evaluator
-        run: | 
+        run: |
+          dart pub get --directory=evaluator 
           dart ./evaluator/bin/main.dart --results-file=./site/data/sites.json
           cat site/data/sites.json
 

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -27,10 +27,10 @@ jobs:
 
       - name: Install SSH Key
         run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< '${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}'
           mkdir -p ~/.ssh/ && touch ~/.ssh/known_hosts
           ssh-keyscan ${{ vars.KNOWN_HOSTS }} >> ~/.ssh/known_hosts
+          eval $(ssh-agent)
+          ssh-add - <<< "${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}"
 
       - name: Checkout Pantheon repo
         run: git clone ${{ vars.PANTHEON_REPO }} pantheon-code

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Terminus
         run: |
@@ -25,14 +25,13 @@ jobs:
         run: |
           terminus auth:login --machine-token ${{ secrets.PANTHEON_MACHINE_TOKEN }}
 
-      - name: Install SSH Key
-        uses: shimataro/ssh-key-action@v2
-        with:
-           key: ${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}
-           known_hosts: ${{ vars.KNOWN_HOSTS }}
-
       - name: Checkout Pantheon repo
-        run: git clone ${{ vars.PANTHEON_REPO }} pantheon-code
+        uses: actions/checkout@v3  
+        with:
+          repository: ${{ vars.PANTHEON_REPO }}
+          path: 'pantheon-code'
+          ssh-key: ${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}
+          ssh-known-hosts: ${{ vars.KNOWN_HOSTS }}
       
       - name: Install Dart
         run: |

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -29,6 +29,7 @@ jobs:
         uses: shimataro/ssh-key-action@v2
         with:
            key: ${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}
+           known_hosts: ${{ vars.KNOWN_HOSTS }}
 
       - name: Checkout Pantheon repo
         run: git clone ${{ vars.PANTHEON_REPO }} pantheon-code

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - feat/pipeline
   schedule:
     - cron: "0 6 * * 1" # Runs at 6 AM on Mondays
 
@@ -40,7 +39,7 @@ jobs:
           dart ./evaluator/bin/main.dart --results-file=./site/data/sites.json
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -55,6 +54,7 @@ jobs:
 
       - name: Deploy to S3
         run: |
+          cd site
           aws s3 sync ./dist/ ${{ vars.AWS_S3_BUCKET }} --delete --acl public-read
 
       - name: Invalidate CloudFront

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Terminus
         run: |
@@ -29,8 +29,10 @@ jobs:
         run: |
           mkdir -p ~/.ssh/ && touch ~/.ssh/known_hosts
           ssh-keyscan ${{ vars.KNOWN_HOSTS }} >> ~/.ssh/known_hosts
+          cat ~/.ssh/known_hosts
           eval $(ssh-agent)
           ssh-add - <<< "${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}"
+          ls -lha ~/.ssh
 
       - name: Checkout Pantheon repo
         run: git clone ${{ vars.PANTHEON_REPO }} pantheon-code

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -32,15 +32,6 @@ jobs:
           name: id_rsa
           known_hosts: ${{ vars.KNOWN_HOSTS }}
 
-      # - name: Install SSH Key
-      #   run: |
-      #     mkdir -p ~/.ssh/ && touch ~/.ssh/known_hosts
-      #     ssh-keyscan ${{ vars.KNOWN_HOSTS }} >> ~/.ssh/known_hosts
-      #     cat ~/.ssh/known_hosts
-      #     eval $(ssh-agent)
-      #     ssh-add - <<< "${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}"
-      #     ls -lha ~/.ssh
-
       - name: Checkout Pantheon repo
         run: git clone ${{ vars.PANTHEON_REPO }} pantheon-code
       
@@ -57,21 +48,12 @@ jobs:
         run: |
           dart pub get --directory=evaluator 
           dart ./evaluator/bin/main.dart --results-file=./site/data/sites.json
-          cat site/data/sites.json
 
-      - name: Save sites.json artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: sites-json
-          path: ./site/data/sites.json
-
-      # - name: Install SSH Key
-      #   uses: shimataro/ssh-key-action@v2
+      # - name: Save sites.json artifact
+      #   uses: actions/upload-artifact@v2
       #   with:
-      #    key: ${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}
-
-      # - name: Checkout Pantheon repo
-      #   run: git clone ${{ vars.PANTHEON_REPO }} pantheon-code
+      #     name: sites-json
+      #     path: ./site/data/sites.json
 
       - name: Build and Generate
         run: |

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
       - name: Install Terminus
         run: |
@@ -25,13 +25,13 @@ jobs:
         run: |
           terminus auth:login --machine-token ${{ secrets.PANTHEON_MACHINE_TOKEN }}
 
+      - name: Install SSH Key
+        run: |
+          eval `ssh-agent -s`
+          ssh-add - <<< '${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}'
+
       - name: Checkout Pantheon repo
-        uses: actions/checkout@v3  
-        with:
-          repository: ${{ vars.PANTHEON_REPO }}
-          path: 'pantheon-code'
-          ssh-key: ${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}
-          ssh-known-hosts: ${{ vars.KNOWN_HOSTS }}
+        run: git clone ${{ vars.PANTHEON_REPO }} pantheon-code
       
       - name: Install Dart
         run: |

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -57,9 +57,10 @@ jobs:
           npm run build
           npm run generate
           rm -rf ../pantheon-code/_nuxt
+          mkdir ../pantheon-code/sinfo
           cp -r dist/* ../pantheon-code/sinfo
           cd ../pantheon-code/sinfo
           git status
-          # git add .
-          # git commit -m "Update sinfo site"
+          # git add --all .
+          # git commit --allow-empty -m "Update sinfo site"
           # git push

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -63,6 +63,6 @@ jobs:
         env:
           PATHS: '/*'
           DISTRIBUTION: ${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ vars.AWS_REGION }}

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -21,21 +21,6 @@ jobs:
           chmod +x terminus.phar
           sudo mv terminus.phar /usr/local/bin/terminus
 
-      - name: Build and Deploy
-        run: |
-          cd site
-          node -v
-          npm install
-          npm run build
-          npm run generate
-          rm -rf ../pantheon-code/sinfo/_nuxt
-          cp -r dist/* ../pantheon-code/sinfo
-          cd ../pantheon-code/sinfo
-          git status
-          # git add .
-          # git commit -m "Update sinfo site"
-          # git push
-
       - name: Authenticate with Pantheon
         run: |
           terminus auth:login --machine-token ${{ secrets.PANTHEON_MACHINE_TOKEN }}
@@ -63,12 +48,6 @@ jobs:
         run: |
           dart pub get --directory=evaluator 
           dart ./evaluator/bin/main.dart --results-file=./site/data/sites.json
-
-      # - name: Save sites.json artifact
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: sites-json
-      #     path: ./site/data/sites.json
 
       - name: Build and Deploy
         run: |

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -24,17 +24,6 @@ jobs:
       - name: Authenticate with Pantheon
         run: |
           terminus auth:login --machine-token ${{ secrets.PANTHEON_MACHINE_TOKEN }}
-
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}
-          name: id_rsa
-          known_hosts: ${{ vars.KNOWN_HOSTS }}
-
-      - name: Checkout Pantheon repo
-        run: |
-          git clone ${{ vars.PANTHEON_REPO }} pantheon-code
       
       - name: Install Dart
         run: |
@@ -45,22 +34,34 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y dart
 
-      - name: Run Dart Evaluator
+      - name: Run Dart
         run: |
           dart pub get --directory=evaluator 
           dart ./evaluator/bin/main.dart --results-file=./site/data/sites.json
 
-      - name: Build and Deploy
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Build static site
         run: |
           cd site
           npm install
           npm run build
           npm run generate
-          rm -rf ../pantheon-code/_nuxt
-          mkdir ../pantheon-code/sinfo
-          cp -r dist/* ../pantheon-code/sinfo
-          cd ../pantheon-code/sinfo
-          git status
-          # git add --all .
-          # git commit --allow-empty -m "Update sinfo site"
-          # git push
+
+      - name: Deploy to S3
+        run: |
+          aws s3 sync ./dist/ ${{ vars.AWS_S3_BUCKET }} --delete --acl public-read
+
+      - name: Invalidate CloudFront
+        uses: chetan/invalidate-cloudfront-action@master
+        env:
+          PATHS: '/*'
+          DISTRIBUTION: ${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ vars.AWS_REGION }}

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -21,6 +21,21 @@ jobs:
           chmod +x terminus.phar
           sudo mv terminus.phar /usr/local/bin/terminus
 
+      - name: Build and Deploy
+        run: |
+          cd site
+          node -v
+          npm install
+          npm run build
+          npm run generate
+          rm -rf ../pantheon-code/sinfo/_nuxt
+          cp -r dist/* ../pantheon-code/sinfo
+          cd ../pantheon-code/sinfo
+          git status
+          # git add .
+          # git commit -m "Update sinfo site"
+          # git push
+
       - name: Authenticate with Pantheon
         run: |
           terminus auth:login --machine-token ${{ secrets.PANTHEON_MACHINE_TOKEN }}
@@ -55,9 +70,10 @@ jobs:
       #     name: sites-json
       #     path: ./site/data/sites.json
 
-      - name: Build and Generate
+      - name: Build and Deploy
         run: |
           cd site
+          npm install
           npm run build
           npm run generate
           rm -rf ../pantheon-code/sinfo/_nuxt

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Authenticate with Pantheon
         run: |
           terminus auth:login --machine-token ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+
+      - name: Checkout Pantheon repo
+        run: git clone ${{ vars.PANTHEON_REPO }} pantheon-code
       
       - name: Install Dart
         run: |
@@ -46,8 +49,13 @@ jobs:
           name: sites-json
           path: ./site/data/sites.json
 
-      - name: Checkout Pantheon repo
-        run: git clone ${{ env.PANTHEON_REPO }} pantheon-code
+      - name: Install SSH Key
+        uses: shimataro/ssh-key-action@v2
+        with:
+         key: ${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}
+
+      # - name: Checkout Pantheon repo
+      #   run: git clone ${{ vars.PANTHEON_REPO }} pantheon-code
 
       - name: Build and Generate
         run: |

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -25,14 +25,21 @@ jobs:
         run: |
           terminus auth:login --machine-token ${{ secrets.PANTHEON_MACHINE_TOKEN }}
 
-      - name: Install SSH Key
-        run: |
-          mkdir -p ~/.ssh/ && touch ~/.ssh/known_hosts
-          ssh-keyscan ${{ vars.KNOWN_HOSTS }} >> ~/.ssh/known_hosts
-          cat ~/.ssh/known_hosts
-          eval $(ssh-agent)
-          ssh-add - <<< "${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}"
-          ls -lha ~/.ssh
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}
+          name: id_rsa
+          known_hosts: ${{ vars.KNOWN_HOSTS }}
+
+      # - name: Install SSH Key
+      #   run: |
+      #     mkdir -p ~/.ssh/ && touch ~/.ssh/known_hosts
+      #     ssh-keyscan ${{ vars.KNOWN_HOSTS }} >> ~/.ssh/known_hosts
+      #     cat ~/.ssh/known_hosts
+      #     eval $(ssh-agent)
+      #     ssh-add - <<< "${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}"
+      #     ls -lha ~/.ssh
 
       - name: Checkout Pantheon repo
         run: git clone ${{ vars.PANTHEON_REPO }} pantheon-code

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -1,0 +1,62 @@
+name: Update sinfo site
+on:
+  push:
+    branches:
+      - main
+      - feat/pipeline
+  schedule:
+    - cron: "0 6 * * 1" # Runs at 6 AM on Mondays
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Terminus
+        run: |
+          wget https://github.com/pantheon-systems/terminus/releases/latest/download/terminus.phar
+          chmod +x terminus.phar
+          sudo mv terminus.phar /usr/local/bin/terminus
+
+      - name: Authenticate with Pantheon
+        run: |
+          terminus auth:login --machine-token ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+      
+      - name: Install Dart
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y apt-transport-https
+          sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
+          sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
+          sudo apt-get update
+          sudo apt-get install -y dart
+
+      - name: Run Dart Evaluator
+        run: | 
+          dart ./evaluator/bin/main.dart --results-file=./site/data/sites.json
+          cat site/data/sites.json
+
+      - name: Save sites.json artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: sites-json
+          path: ./site/data/sites.json
+
+      - name: Checkout Pantheon repo
+        run: git clone ${{ env.PANTHEON_REPO }} pantheon-code
+
+      - name: Build and Generate
+        run: |
+          cd site
+          npm run build
+          npm run generate
+          rm -rf ../pantheon-code/sinfo/_nuxt
+          cp -r dist/* ../pantheon-code/sinfo
+          cd ../pantheon-code/sinfo
+          git status
+          # git add .
+          # git commit -m "Update sinfo site"
+          # git push

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -33,7 +33,10 @@ jobs:
           known_hosts: ${{ vars.KNOWN_HOSTS }}
 
       - name: Checkout Pantheon repo
-        run: git clone ${{ vars.PANTHEON_REPO }} pantheon-code
+        run: |
+          git clone ${{ vars.PANTHEON_REPO }} pantheon-code
+          ls -lha
+          ls -lha pantheon-code
       
       - name: Install Dart
         run: |

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - feat/pipeline
   schedule:
     - cron: "0 6 * * 1" # Runs at 6 AM on Mondays
 

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -35,8 +35,6 @@ jobs:
       - name: Checkout Pantheon repo
         run: |
           git clone ${{ vars.PANTHEON_REPO }} pantheon-code
-          ls -lha
-          ls -lha pantheon-code
       
       - name: Install Dart
         run: |
@@ -58,7 +56,7 @@ jobs:
           npm install
           npm run build
           npm run generate
-          rm -rf ../pantheon-code/sinfo/_nuxt
+          rm -rf ../pantheon-code/_nuxt
           cp -r dist/* ../pantheon-code/sinfo
           cd ../pantheon-code/sinfo
           git status

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -25,6 +25,11 @@ jobs:
         run: |
           terminus auth:login --machine-token ${{ secrets.PANTHEON_MACHINE_TOKEN }}
 
+      - name: Install SSH Key
+        uses: shimataro/ssh-key-action@v2
+        with:
+           key: ${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}
+
       - name: Checkout Pantheon repo
         run: git clone ${{ vars.PANTHEON_REPO }} pantheon-code
       
@@ -49,10 +54,10 @@ jobs:
           name: sites-json
           path: ./site/data/sites.json
 
-      - name: Install SSH Key
-        uses: shimataro/ssh-key-action@v2
-        with:
-         key: ${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}
+      # - name: Install SSH Key
+      #   uses: shimataro/ssh-key-action@v2
+      #   with:
+      #    key: ${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}
 
       # - name: Checkout Pantheon repo
       #   run: git clone ${{ vars.PANTHEON_REPO }} pantheon-code

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -29,6 +29,8 @@ jobs:
         run: |
           eval `ssh-agent -s`
           ssh-add - <<< '${{ secrets.PANTHEON_PRIVATE_SSH_KEY }}'
+          mkdir -p ~/.ssh/ && touch ~/.ssh/known_hosts
+          ssh-keyscan ${{ vars.KNOWN_HOSTS }} >> ~/.ssh/known_hosts
 
       - name: Checkout Pantheon repo
         run: git clone ${{ vars.PANTHEON_REPO }} pantheon-code

--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - feat/pipeline
   schedule:
     - cron: "0 6 * * 1" # Runs at 6 AM on Mondays
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This example can be used to update the json file expected by the Vue app.
 
 ```zsh
 terminus auth:login --email=username@clockwork.com
-
+dart pub get --directory=evaluator
 dart ./evaluator/bin/main.dart --results-file=./site/data/sites.json
 ```
 
@@ -48,18 +48,14 @@ dart test
 1. Open this file `evaluator/lib/evaluator.dart`
 2. Edit the contents of the variable `_phpVersions`
 
-### Updating Pantheon with New Data
+### Updating S3 bucket with New Data
 
 ```zsh
 dart ./evaluator/bin/main.dart --results-file=./site/data/sites.json
 cd site
 npm run build
 npm run generate
-rm -rf path-to-pantheon-repo/sinfo/_nuxt
-cp -r dist/* path-to-pantheon-repo/sinfo
-cd path-to-pantheon-repo/sinfo
-git add .
-git push
+aws s3 sync ./dist/ ${{ vars.AWS_S3_BUCKET }} --delete --acl public-read
 ```
 
 ## In Progress Work -- Items not done yet

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The evaluator is a Dart script. The script performs these high-level actions:
 This example can be used to update the json file expected by the Vue app.
 
 ```zsh
+terminus auth:login --email=username@clockwork.com
+
 dart ./evaluator/bin/main.dart --results-file=./site/data/sites.json
 ```
 


### PR DESCRIPTION
This PR adds a deployment pipeline to automate the generation of the `sites.json` file via dart as well as deploying to an S3 bucket. 

It is setup to run on any merges to `main` and every Monday morning.

See [this link](https://github.com/ClockworkNet/pantheon-site-status/actions/runs/5601925085) for an example of the pipeline running from start to finish.