### PR TITLE
fix: updaing upload-artifact action to v4

### DIFF
--- a/.github/workflows/update-sinfo.yml
+++ b/.github/workflows/update-sinfo.yml
@@ -41,7 +41,7 @@ jobs:
           dart ./evaluator/bin/main.dart --results-file=./site/data/sites.json
 
       - name: Save artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sites-json
           path: ./site/data/sites.json


### PR DESCRIPTION
Description:

`actions/upload-artifact@v3` was deprecated on November 30, 2024. Bumping to v4. See: https://github.com/actions/upload-artifact